### PR TITLE
ci: add Dependabot config for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds/updates .github/dependabot.yml to keep GitHub Actions dependencies updated weekly via Dependabot.